### PR TITLE
Add LiteLLM support for multiple providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# Paper2Code .env file example
+# Copy this file to .env and modify as needed
+
+# IMPORTANT: When using LiteLLM, ensure you have both litellm AND any provider-specific
+# dependencies installed. For AWS Bedrock, this includes boto3.
+
+# Uncomment ONE of the following provider configurations:
+
+# 1. AWS Bedrock Configuration
+AWS_REGION=us-west-2
+BEDROCK_MODEL=anthropic.claude-3-sonnet-20240229-v1:0
+DISABLE_PROMPT_CACHING=0  # Set to 1 to disable caching
+AWS_SHARED_CREDENTIALS_FILE=~/.aws/credentials
+AWS_CONFIG_FILE=~/.aws/config
+# NOTE: For AWS Bedrock, you must:
+# 1. Have boto3 installed (pip install boto3)
+# 2. Have valid AWS credentials configured
+# 3. Have appropriate permissions to use the specified model
+
+# 2. OpenAI
+# OPENAI_API_KEY=your_api_key_here
+# OPENAI_MODEL=o3-mini  # Default if not specified
+
+# 3. Direct Anthropic API (not Bedrock)
+# ANTHROPIC_API_KEY=your_api_key_here
+# ANTHROPIC_MODEL=claude-3-sonnet-20240229  # Default if not specified
+
+
+# Paper-specific settings (these should be set via command line args or script)
+# PAPER_NAME=Transformer
+# PDF_PATH=./examples/Transformer.pdf
+# PDF_JSON_PATH=./examples/Transformer.json
+# PDF_JSON_CLEANED_PATH=./examples/Transformer_cleaned.json
+# PDF_LATEX_PATH=./examples/Transformer_cleaned.tex
+# OUTPUT_DIR=./outputs/Transformer
+# OUTPUT_REPO_DIR=./outputs/Transformer_repo

--- a/README.md
+++ b/README.md
@@ -45,6 +45,55 @@ cd scripts
 bash run_llm.sh
 ```
 
+### Using Other LLM Providers with LiteLLM
+- PaperCoder now supports any LLM provider available through [LiteLLM](https://github.com/BerriAI/litellm)
+- Configure your model settings in a `.env` file in the project root directory (see `.env.example`)
+- Supports standard LiteLLM provider syntax including:
+  - AWS Bedrock (`bedrock/model-name`) - requires boto3
+  - OpenAI (`openai/model-name`) - uses o3-mini by default
+  - Anthropic (`anthropic/model-name`) - direct API access
+
+#### LiteLLM Provider Configurations
+Choose ONE of the following provider configurations in your .env file:
+
+##### 1. AWS Bedrock
+```
+AWS_REGION=<your-region>
+BEDROCK_MODEL=<model-name>  # e.g., anthropic.claude-3-sonnet-20240229-v1:0
+DISABLE_PROMPT_CACHING=0
+AWS_SHARED_CREDENTIALS_FILE=~/.aws/credentials
+AWS_CONFIG_FILE=~/.aws/config
+```
+
+##### 2. OpenAI
+```
+OPENAI_API_KEY=<your-openai-api-key>
+OPENAI_MODEL=o3-mini  # Default if not specified
+```
+
+##### 3. Anthropic Direct API
+```
+ANTHROPIC_API_KEY=<your-anthropic-api-key>
+ANTHROPIC_MODEL=claude-3-sonnet-20240229  # Default if not specified
+```
+
+```bash
+# Install LiteLLM
+pip install litellm
+
+# For provider-specific dependencies:
+# - AWS Bedrock requires boto3
+pip install boto3
+
+# Copy and modify the example .env file
+cp .env.example .env
+# Edit the .env file with your provider configuration
+
+# Run the scripts - they will use LiteLLM if configured or fall back to vLLM
+cd scripts
+bash run_llm.sh
+```
+
 ### Output Folder Structure (Only Important Files)
 ```bash
 outputs
@@ -65,11 +114,14 @@ outputs
   - For OpenAI API: `openai`
   - For open-source models: `vllm`
       - If you encounter any issues installing vLLM, please refer to the [official vLLM repository](https://github.com/vllm-project/vllm).
+  - For other LLM providers (like AWS Bedrock): `litellm`
+      - Check the [LiteLLM documentation](https://github.com/BerriAI/litellm) for supported models and configurations.
 
 
 ```bash
 pip install openai 
-pip install vllm 
+pip install vllm
+pip install litellm
 ```
 
 - Or, if you prefer, you can install all dependencies using `pip`:
@@ -132,8 +184,9 @@ bash run_latex.sh
 ```
 
 
-#### Using Open Source Models with vLLM
-- The default model is `deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct`.
+#### Using Open Source Models with vLLM or LiteLLM
+- The default model is `deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct` (using vLLM)
+- For LiteLLM integration, create a `.env` file in the project root with your provider configuration
 
 ```bash
 # Using the PDF-based JSON format of the paper
@@ -145,6 +198,23 @@ bash run_llm.sh
 # Using the LaTeX source of the paper
 cd scripts
 bash run_latex_llm.sh
+```
+
+```bash
+# Example .env configuration (AWS Bedrock with Claude)
+AWS_REGION=eu-north-1
+BEDROCK_MODEL=anthropic.claude-3-sonnet-20240229-v1:0
+DISABLE_PROMPT_CACHING=0
+AWS_SHARED_CREDENTIALS_FILE=~/.aws/credentials
+AWS_CONFIG_FILE=~/.aws/config
+
+# Or for OpenAI
+# OPENAI_API_KEY=your-api-key
+# OPENAI_MODEL=o3-mini
+
+# Or for Anthropic Direct API
+# ANTHROPIC_API_KEY=your-api-key
+# ANTHROPIC_MODEL=claude-3-sonnet-20240229
 ```
 
 ---

--- a/codes/1_planning_llm.py
+++ b/codes/1_planning_llm.py
@@ -3,8 +3,11 @@ import argparse
 import os
 import sys
 from utils import print_response
-from transformers import AutoTokenizer
-from vllm import LLM, SamplingParams
+from load_dotenv import load_env_config
+from litellm_utils import get_llm_client, run_inference
+
+# Load environment variables
+load_env_config()
 
 parser = argparse.ArgumentParser()
 
@@ -221,37 +224,17 @@ training:
     }]
 
 
-model_name = args.model_name
-tokenizer = AutoTokenizer.from_pretrained(model_name)
-
-
-if "Qwen" in model_name:
-    llm = LLM(model=model_name, 
-            tensor_parallel_size=tp_size, 
-            max_model_len=max_model_len,
-            gpu_memory_utilization=0.95,
-            trust_remote_code=True, enforce_eager=True, 
-            rope_scaling={"factor": 4.0, "original_max_position_embeddings": 32768, "type": "yarn"})
-    sampling_params = SamplingParams(temperature=temperature, max_tokens=131072)
-
-elif "deepseek" in model_name:
-    llm = LLM(model=model_name, 
-              tensor_parallel_size=tp_size, 
-              max_model_len=max_model_len,
-              gpu_memory_utilization=0.95,
-              trust_remote_code=True, enforce_eager=True)
-    sampling_params = SamplingParams(temperature=temperature, max_tokens=128000, stop_token_ids=[tokenizer.eos_token_id])
-
+# Initialize LLM client (either LiteLLM from environment or vLLM from args)
+client, tokenizer, is_litellm, sampling_params = get_llm_client(
+    model_name=model_name, 
+    tp_size=tp_size, 
+    max_model_len=max_model_len,
+    temperature=temperature
+)
 
 def run_llm(msg):
-    # vllm
-    prompt_token_ids = [tokenizer.apply_chat_template(messages, add_generation_prompt=True) for messages in [msg]]
-
-    outputs = llm.generate(prompt_token_ids=prompt_token_ids, sampling_params=sampling_params)
-
-    completion = [output.outputs[0].text for output in outputs]
-    
-    return completion[0] 
+    """Run inference using either LiteLLM or vLLM based on configuration"""
+    return run_inference(client, tokenizer, is_litellm, sampling_params, msg) 
 
 responses = []
 trajectories = []

--- a/codes/3_coding_llm.py
+++ b/codes/3_coding_llm.py
@@ -4,10 +4,13 @@ from tqdm import tqdm
 import sys
 import copy
 from utils import extract_planning, content_to_json, extract_code_from_content,extract_code_from_content2, print_response, print_log_cost, load_accumulated_cost, save_accumulated_cost
-from transformers import AutoTokenizer
-from vllm import LLM, SamplingParams
+from load_dotenv import load_env_config
+from litellm_utils import get_llm_client, run_inference
 
 import argparse
+
+# Load environment variables
+load_env_config()
 
 parser = argparse.ArgumentParser()
 
@@ -154,37 +157,17 @@ Next, you must write only the "{todo_file_name}".
 ## Code: {todo_file_name}"""}]
     return write_msg
 
-model_name = args.model_name
-tokenizer = AutoTokenizer.from_pretrained(model_name)
-
-
-if "Qwen" in model_name:
-    llm = LLM(model=model_name, 
-            tensor_parallel_size=tp_size, 
-            max_model_len=max_model_len,
-            gpu_memory_utilization=0.95,
-            trust_remote_code=True, enforce_eager=True, 
-            rope_scaling={"factor": 4.0, "original_max_position_embeddings": 32768, "type": "yarn"})
-    sampling_params = SamplingParams(temperature=temperature, max_tokens=131072)
-
-elif "deepseek" in model_name:
-    llm = LLM(model=model_name, 
-              tensor_parallel_size=tp_size, 
-              max_model_len=max_model_len,
-              gpu_memory_utilization=0.95,
-              trust_remote_code=True, enforce_eager=True)
-    sampling_params = SamplingParams(temperature=temperature, max_tokens=128000, stop_token_ids=[tokenizer.eos_token_id])
-
+# Initialize LLM client (either LiteLLM from environment or vLLM from args)
+client, tokenizer, is_litellm, sampling_params = get_llm_client(
+    model_name=model_name, 
+    tp_size=tp_size, 
+    max_model_len=max_model_len,
+    temperature=temperature
+)
 
 def run_llm(msg):
-    # vllm
-    prompt_token_ids = [tokenizer.apply_chat_template(messages, add_generation_prompt=True) for messages in [msg]]
-
-    outputs = llm.generate(prompt_token_ids=prompt_token_ids, sampling_params=sampling_params)
-
-    completion = [output.outputs[0].text for output in outputs]
-    
-    return completion[0] 
+    """Run inference using either LiteLLM or vLLM based on configuration"""
+    return run_inference(client, tokenizer, is_litellm, sampling_params, msg) 
     
 
 # testing for checking

--- a/codes/litellm_utils.py
+++ b/codes/litellm_utils.py
@@ -1,0 +1,172 @@
+import os
+import litellm
+from typing import List, Dict, Any, Optional, Union
+from transformers import AutoTokenizer
+from load_dotenv import load_env_config
+
+def initialize_litellm():
+    """
+    Initialize LiteLLM with configuration from environment variables.
+    Must be called after load_env_config().
+    """
+    # Load environment variables if not already loaded
+    load_env_config()
+    
+    try:
+        # Check for different provider configurations in environment
+        if os.environ.get("AWS_REGION_NAME") or (os.environ.get("AWS_REGION") and os.environ.get("BEDROCK_MODEL")):
+            # AWS Bedrock configuration detected
+            try:
+                import boto3
+            except ImportError:
+                print("WARNING: boto3 is required for AWS Bedrock but is not installed.")
+                print("Please install it with 'pip install boto3'")
+                return None
+            
+            # Set region from either standard variable or our custom one
+            if os.environ.get("AWS_REGION") and not os.environ.get("AWS_REGION_NAME"):
+                os.environ["AWS_REGION_NAME"] = os.environ.get("AWS_REGION")
+            
+            # Get model name
+            model_name = os.environ.get("BEDROCK_MODEL", "anthropic.claude-3-sonnet-20240229-v1:0")
+            bedrock_model = f"bedrock/{model_name}"
+            
+            # Set AWS credentials paths if provided
+            if os.environ.get("AWS_SHARED_CREDENTIALS_FILE"):
+                os.environ["AWS_SHARED_CREDENTIALS_FILE"] = os.path.expanduser(os.environ.get("AWS_SHARED_CREDENTIALS_FILE"))
+            
+            if os.environ.get("AWS_CONFIG_FILE"):
+                os.environ["AWS_CONFIG_FILE"] = os.path.expanduser(os.environ.get("AWS_CONFIG_FILE"))
+            
+            # Configure caching
+            if os.environ.get("DISABLE_PROMPT_CACHING") == "1":
+                litellm.cache = None
+            
+            print(f"LiteLLM configured to use AWS Bedrock with model: {bedrock_model}")
+            return bedrock_model
+            
+        elif os.environ.get("OPENAI_API_KEY"):
+            # OpenAI configuration detected
+            model_name = os.environ.get("OPENAI_MODEL", "o3-mini")
+            openai_model = f"openai/{model_name}"
+            print(f"LiteLLM configured to use OpenAI with model: {openai_model}")
+            return openai_model
+            
+        elif os.environ.get("ANTHROPIC_API_KEY"):
+            # Anthropic configuration detected
+            model_name = os.environ.get("ANTHROPIC_MODEL", "claude-3-sonnet-20240229")
+            anthropic_model = f"anthropic/{model_name}"
+            print(f"LiteLLM configured to use Anthropic with model: {anthropic_model}")
+            return anthropic_model
+            
+        else:
+            # No LiteLLM provider configuration detected
+            print("Using model specified via command line args (no LiteLLM configuration detected)")
+            return None
+    except Exception as e:
+        print(f"WARNING: Failed to initialize LiteLLM: {str(e)}")
+        print("Falling back to vLLM implementation")
+        return None
+
+def get_llm_client(model_name: str, tp_size: int = 2, max_model_len: int = 128000, temperature: float = 1.0):
+    """
+    Get an LLM client based on the environment configuration.
+    
+    Args:
+        model_name: The model to use (may be overridden by env vars)
+        tp_size: tensor parallel size for vLLM
+        max_model_len: maximum model length for vLLM
+        temperature: sampling temperature
+        
+    Returns:
+        A tuple of (client, tokenizer, is_litellm, sampling_params)
+    """
+    # Try to initialize LiteLLM first
+    litellm_model = initialize_litellm()
+    
+    # If LiteLLM is configured, use it
+    if litellm_model:
+        tokenizer = None  # LiteLLM handles tokenization
+        return litellm_model, tokenizer, True, {"temperature": temperature}
+    
+    # Otherwise use vLLM implementation
+    try:
+        from vllm import LLM, SamplingParams
+        
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        
+        if "Qwen" in model_name:
+            llm = LLM(model=model_name, 
+                    tensor_parallel_size=tp_size, 
+                    max_model_len=max_model_len,
+                    gpu_memory_utilization=0.95,
+                    trust_remote_code=True, enforce_eager=True, 
+                    rope_scaling={"factor": 4.0, "original_max_position_embeddings": 32768, "type": "yarn"})
+            sampling_params = SamplingParams(temperature=temperature, max_tokens=131072)
+        
+        elif "deepseek" in model_name:
+            llm = LLM(model=model_name, 
+                    tensor_parallel_size=tp_size, 
+                    max_model_len=max_model_len,
+                    gpu_memory_utilization=0.95,
+                    trust_remote_code=True, enforce_eager=True)
+            sampling_params = SamplingParams(temperature=temperature, max_tokens=128000, stop_token_ids=[tokenizer.eos_token_id])
+        
+        else:
+            # Generic configuration for other models
+            llm = LLM(model=model_name,
+                    tensor_parallel_size=tp_size,
+                    max_model_len=max_model_len,
+                    gpu_memory_utilization=0.95,
+                    trust_remote_code=True)
+            sampling_params = SamplingParams(temperature=temperature, max_tokens=128000)
+        
+        return llm, tokenizer, False, sampling_params
+    except ImportError:
+        raise ImportError("vLLM is not installed. Please install it with 'pip install vllm' to use this mode")
+    except Exception as e:
+        raise RuntimeError(f"Failed to initialize vLLM: {str(e)}")
+
+def run_inference(client, tokenizer, is_litellm, sampling_params, messages):
+    """
+    Run inference using either LiteLLM or vLLM.
+    
+    Args:
+        client: The LLM client (either LiteLLM model name or vLLM instance)
+        tokenizer: Tokenizer for vLLM (None for LiteLLM)
+        is_litellm: Whether we're using LiteLLM
+        sampling_params: Parameters for sampling
+        messages: The messages to process
+        
+    Returns:
+        Generated completion text
+    """
+    if is_litellm:
+        # Use LiteLLM for inference with exponential backoff retry (prevents stopping with service bottlenecks)
+        import time
+        max_retries = 10
+        retry_delay = 1  # start with 1 second
+        
+        for attempt in range(max_retries):
+            try:
+                response = litellm.completion(
+                    model=client,
+                    messages=messages,
+                    temperature=sampling_params.get("temperature", 1.0)
+                )
+                return response.choices[0].message.content
+            except Exception as e:
+                print(f"Attempt {attempt+1}/{max_retries} failed: {str(e)}")
+                if attempt < max_retries - 1:
+                    print(f"Retrying in {retry_delay} seconds...")
+                    time.sleep(retry_delay)
+                    retry_delay *= 2  # Double the wait time
+                else:
+                    print(f"All {max_retries} attempts failed")
+                    raise RuntimeError(f"LiteLLM failed after {max_retries} attempts: {str(e)}")
+    else:
+        # Use vLLM for inference
+        prompt_token_ids = [tokenizer.apply_chat_template(messages, add_generation_prompt=True)]
+        outputs = client.generate(prompt_token_ids=prompt_token_ids, sampling_params=sampling_params)
+        completion = [output.outputs[0].text for output in outputs]
+        return completion[0]

--- a/codes/load_dotenv.py
+++ b/codes/load_dotenv.py
@@ -1,0 +1,60 @@
+import os
+from dotenv import load_dotenv
+import sys
+
+def load_env_config():
+    """
+    Load environment variables from .env file.
+    This function should be imported and called at the beginning of each script
+    that needs access to environment variables.
+    
+    Returns:
+        bool: True if .env file was loaded successfully, False otherwise
+    """
+    # Get the project root directory (assumes this file is in the codes/ directory)
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    
+    # Path to the .env file
+    env_path = os.path.join(project_root, '.env')
+    
+    # Load environment variables from .env file
+    if os.path.exists(env_path):
+        load_dotenv(env_path)
+        print(f"Loaded environment variables from {env_path}")
+        return True
+    else:
+        print(f"Warning: .env file not found at {env_path}", file=sys.stderr)
+        return False
+
+if __name__ == "__main__":
+    # If run directly, just load the environment variables
+    load_env_config()
+    
+    # Print all environment variables (for debugging)
+    env_vars = [
+        "OPENAI_API_KEY", 
+        "GPT_VERSION",
+        "PAPER_NAME",
+        "PDF_PATH",
+        "PDF_JSON_PATH", 
+        "PDF_JSON_CLEANED_PATH",
+        "PDF_LATEX_PATH",
+        "OUTPUT_DIR", 
+        "OUTPUT_REPO_DIR"
+    ]
+    
+    # LiteLLM environment variables
+    litellm_vars = [
+        "AWS_REGION",
+        "ANTHROPIC_MODEL",
+        "DISABLE_PROMPT_CACHING",
+        "AWS_SHARED_CREDENTIALS_FILE",
+        "AWS_CONFIG_FILE"
+    ]
+    
+    for var in env_vars + litellm_vars:
+        # Mask API keys for security
+        if var in ["OPENAI_API_KEY"] and os.environ.get(var):
+            print(f"{var}=***********{os.environ.get(var)[-4:]}")
+        else:
+            print(f"{var}={os.environ.get(var, 'Not set')}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ openai>=1.65.4
 vllm>=0.6.4.post1
 transformers>=4.46.3
 tiktoken>=0.9.0
+python-dotenv>=1.0.0
+litellm>=1.17.0
+boto3>=1.28.0


### PR DESCRIPTION
- Added LiteLLM integration for AWS Bedrock, OpenAI, and Anthropic
- Created standardized environment variable configuration system
- Added load_dotenv.py for loading .env configurations
- Updated all LLM implementation files to use LiteLLM when configured
- Added retry mechanism with exponential backoff for rate limiting
- Updated documentation with configuration examples for different providers
- Added .env.example template for easy configuration

NOTE:
I have only tested this branch with LiteLLM using AWS Bedrock (anthropic.claude-3-7-sonnet-20250219-v1:0).
I HAVE NOT tested LiteLLM with OpenAI or Anthropic direct APIs NOR the vLLM setup